### PR TITLE
Fix parking lot cache check

### DIFF
--- a/go/server.go
+++ b/go/server.go
@@ -51,7 +51,7 @@ func (s *Server) handleParkingLots(w http.ResponseWriter, r *http.Request) {
 	}
 
 	parkingLots := s.cache.GetAllParkingLots()
-	if parkingLots != nil {
+	if len(parkingLots) > 0 {
 		send(parkingLots)
 		return
 	}


### PR DESCRIPTION
## Summary
- handleParkingLots uses len check instead of nil to determine cache state

## Testing
- `go test ./...` *(fails: fetching modules Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a460dc00c8323ada463a62ceae6b3