### PR TITLE
Fix mobile build text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Try it out at [web.wheretopark.app](https://web.wheretopark.app).
 
 ### iOS & Android
 
-iOS was initially developed with Swift and SwiftUI, right now it works similarly as Android - the web app is compiled with [capacitor.js](https://capacitorjs.com) to work on mobile.
+iOS was initially developed with Swift and SwiftUI, right now it works similarly as Android - the web app is compiled with [Capacitor](https://capacitorjs.com) to work on mobile.
 
 
 iOS app can be installed from [App Store](https://apps.apple.com/us/app/where-to-park/id6444453582).


### PR DESCRIPTION
## Summary
- update README to clarify the mobile build uses Capacitor

## Testing
- `go test ./...` *(fails: failed to fetch modules)*
- `npm test` in app *(fails: vitest not found)*
- `npm test` in visel *(fails: missing script)*
- `npm test` in landing *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a461502548323bd10a2f11283ea60