### PR TITLE
Refactor server client test to avoid network

### DIFF
--- a/go/server_client_test.go
+++ b/go/server_client_test.go
@@ -1,35 +1,70 @@
 package wheretopark_test
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"testing"
+
 	wheretopark "wheretopark/go"
 )
 
 func TestServerClient(t *testing.T) {
-	url, err := url.Parse("https://api.wheretopark.app")
+	var provider1URL, provider2URL string
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/v1/config/providers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		providers := []map[string]string{
+			{"name": "provider1", "url": provider1URL},
+			{"name": "provider2", "url": provider2URL},
+		}
+		json.NewEncoder(w).Encode(providers)
+	})
+
+	mux.HandleFunc("/v1/provider/provider1/parking-lots", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		lots := map[string]wheretopark.ParkingLot{"A": sampleParkingLot}
+		json.NewEncoder(w).Encode(lots)
+	})
+
+	mux.HandleFunc("/v1/provider/provider2/parking-lots", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		lots := map[string]wheretopark.ParkingLot{"B": sampleParkingLot}
+		json.NewEncoder(w).Encode(lots)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider1URL = server.URL + "/v1/provider/provider1"
+	provider2URL = server.URL + "/v1/provider/provider2"
+
+	base, err := url.Parse(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := wheretopark.NewServerClient(url)
+	c := wheretopark.NewServerClient(base)
+
 	providers, err := c.Providers()
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(providers) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(providers))
+	}
+
 	allParkingLots := make(map[wheretopark.ID]wheretopark.ParkingLot)
 	for _, provider := range providers {
-		t.Logf("fetching from %s. URL: %s", provider.Name, provider.URL.String())
 		parkingLots, err := c.GetFrom(provider)
 		if err != nil {
 			t.Fatalf("failed to fetch from %s: %s", provider.Name, err)
 		}
-		t.Logf("fetched %d parking lots from %s", len(parkingLots), provider.Name)
 		for id, parkingLot := range parkingLots {
 			allParkingLots[id] = parkingLot
 		}
 	}
-
-	t.Logf("fetched %d parking lots from %d providers", len(allParkingLots), len(providers))
 
 	allParkingLots2, err := c.GetFromMany(providers)
 	if err != nil {


### PR DESCRIPTION
## Summary
- use `httptest.Server` in `go/server_client_test.go`
- stub `/v1/config/providers` and `/parking-lots` endpoints for testing

## Testing
- `go test ./...` *(fails: Forbidden downloads)*

------
https://chatgpt.com/codex/tasks/task_e_684a462a049083238bedba548e55b77b